### PR TITLE
Fix code comments inheritance by removing conflicting <include> tags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Threading/issues/10
-Your prepared branch: issue-10-50f9dd07
-Your prepared working directory: /tmp/gh-issue-solver-1757841743594
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Threading/issues/10
+Your prepared branch: issue-10-50f9dd07
+Your prepared working directory: /tmp/gh-issue-solver-1757841743594
+
+Proceed.

--- a/csharp/Platform.Threading/Synchronization/ReaderWriterLockSynchronization.cs
+++ b/csharp/Platform.Threading/Synchronization/ReaderWriterLockSynchronization.cs
@@ -12,7 +12,6 @@ namespace Platform.Threading.Synchronization
     {
         private readonly ReaderWriterLockSlim _rwLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
 
-        /// <include file='bin\Release\netstandard2.0\Platform.Threading.xml' path='doc/members/member[@name="M:Platform.Threading.Synchronization.ISynchronization.DoRead(System.Action)"]/*'/>
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void DoRead(Action action)
@@ -28,7 +27,6 @@ namespace Platform.Threading.Synchronization
             }
         }
 
-        /// <include file='bin\Release\netstandard2.0\Platform.Threading.xml' path='doc/members/member[@name="M:Platform.Threading.Synchronization.ISynchronization.DoRead``1(System.Func{``0})"]/*'/>
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public TResult DoRead<TResult>(Func<TResult> function)
@@ -44,7 +42,6 @@ namespace Platform.Threading.Synchronization
             }
         }
 
-        /// <include file='bin\Release\netstandard2.0\Platform.Threading.xml' path='doc/members/member[@name="M:Platform.Threading.Synchronization.ISynchronization.DoWrite(System.Action)"]/*'/>
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void DoWrite(Action action)
@@ -60,7 +57,6 @@ namespace Platform.Threading.Synchronization
             }
         }
 
-        /// <include file='bin\Release\netstandard2.0\Platform.Threading.xml' path='doc/members/member[@name="M:Platform.Threading.Synchronization.ISynchronization.DoWrite``1(System.Func{``0})"]/*'/>
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public TResult DoWrite<TResult>(Func<TResult> function)

--- a/csharp/Platform.Threading/Synchronization/Unsynchronization.cs
+++ b/csharp/Platform.Threading/Synchronization/Unsynchronization.cs
@@ -9,22 +9,18 @@ namespace Platform.Threading.Synchronization
     /// </summary>
     public class Unsynchronization : ISynchronization
     {
-        /// <include file='bin\Release\netstandard2.0\Platform.Threading.xml' path='doc/members/member[@name="M:Platform.Threading.Synchronization.ISynchronization.DoRead(System.Action)"]/*'/>
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void DoRead(Action action) => action();
 
-        /// <include file='bin\Release\netstandard2.0\Platform.Threading.xml' path='doc/members/member[@name="M:Platform.Threading.Synchronization.ISynchronization.DoRead``1(System.Func{``0})"]/*'/>
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public TResult DoRead<TResult>(Func<TResult> function) => function();
 
-        /// <include file='bin\Release\netstandard2.0\Platform.Threading.xml' path='doc/members/member[@name="M:Platform.Threading.Synchronization.ISynchronization.DoWrite(System.Action)"]/*'/>
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void DoWrite(Action action) => action();
 
-        /// <include file='bin\Release\netstandard2.0\Platform.Threading.xml' path='doc/members/member[@name="M:Platform.Threading.Synchronization.ISynchronization.DoWrite``1(System.Func{``0})"]/*'/>
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public TResult DoWrite<TResult>(Func<TResult> function) => function();


### PR DESCRIPTION
## Summary

This PR fixes code comments inheritance issues in the Threading library by removing conflicting `<include>` tags and keeping only `<inheritdoc/>` tags for proper documentation inheritance.

## Problem

The current implementation had both `<include>` tags referencing XML build output files and `<inheritdoc/>` tags on the same methods, causing conflicts that prevented DocFX from properly inheriting XML documentation comments from the interface methods.

## Solution

- **Removed all `<include>` tags** that referenced `bin\Release\netstandard2.0\Platform.Threading.xml` 
- **Kept only `<inheritdoc/>` tags** for clean documentation inheritance from `ISynchronization` interface methods
- Applied changes to both `ReaderWriterLockSynchronization` and `Unsynchronization` classes

## Files Changed

- `csharp/Platform.Threading/Synchronization/ReaderWriterLockSynchronization.cs`
- `csharp/Platform.Threading/Synchronization/Unsynchronization.cs`

## Benefits

- ✅ DocFX will now properly inherit XML documentation from interface methods
- ✅ Cleaner documentation generation without conflicts
- ✅ Follows .NET documentation inheritance best practices
- ✅ Resolves related issue #11 about DocFX inheritance failures

## Testing

The changes maintain all existing `<inheritdoc/>` tags (8 total) while removing problematic `<include>` tags that caused inheritance conflicts.

Fixes #10

🤖 Generated with [Claude Code](https://claude.ai/code)